### PR TITLE
add `unitt` package

### DIFF
--- a/packages/list.art
+++ b/packages/list.art
@@ -1,1 +1,2 @@
 dummy: "arturo-lang/dummy-package"
+unitt: "RickBarretto/unitt"


### PR DESCRIPTION
# 📖 Description

Unitt is a basic unit-test tool for the Arturo Programming language.

## 📦 New package

- [x] I have updated the [packages/list.art](https://github.com/arturo-lang/pkgr.art/blob/main/packages/list.art):
    * All you have to do is add an entry like:
       ```red
       packageName: "owner/repo"
       ```
- [x] The repo in question is formatted as a valid Arturo package:
    * either have a `main.art` file and/or an `info.art` file specifying the entry point, `depends` and `requires`
- [x] There is at least one published release:
    * Arturo's package manager versioning uses the published releases' tags which have to conform to SemVer

## 🗒 Notes
* My first publish is marked as pre-release
* I'm not using `main.art`, but `unitt.art`, declared in the entry.

My current `info.art`:

```art
entry: {unitt}
depends: []
requires: 0.9.83
```
