### PR TITLE
Misc UI & Website fixes

### DIFF
--- a/tools/generateweb.art
+++ b/tools/generateweb.art
@@ -133,7 +133,7 @@ loop packages [k,v][
 ]
 
 processPackagePage: function [entry][
-    packageTitle: entry\info\name ++ " &bull; "
+    packageTitle: entry\name ++ " &bull; "
     postprocessHTML render.template read "website/package.html" entry\info\fullName
 ]
 

--- a/tools/generateweb.art
+++ b/tools/generateweb.art
@@ -175,6 +175,10 @@ loop entries 'entry [
     ]
 ]
 
+entries: arrange.descending entries 'entry [
+    entry\version\0\date
+]
+
 if odd? size entries ->
     'entries ++ null
 

--- a/tools/generateweb.art
+++ b/tools/generateweb.art
@@ -29,6 +29,7 @@ getProperMarkdown: function [md][
     ; ret: read.markdown md
     delete "tmp.md"
     ret: replace ret {/class="language-[^"]+"/} ""
+    ret: replace ret {<a href="http} {<a rel="nofollow" target="_blank" href="http}
     return ret
 ]
 

--- a/tools/generateweb.art
+++ b/tools/generateweb.art
@@ -52,9 +52,8 @@ getPackageBox: function [entry][
 ]
 
 getCleanTags: function [taglist][
-    filter taglist 'tag [
-        contains? ["arturo" "arturo-lang" "package"] tag
-    ]
+    taglist | filter 'tag [contains? ["arturo" "arturo-lang" "arturo-language", "pkgr-art", "package"] tag]
+            | map 'tag [replace tag "-" " "]
 ]
 
 octicon: function [icon][

--- a/tools/gfm.rb
+++ b/tools/gfm.rb
@@ -4,7 +4,8 @@ puts Commonmarker.to_html(File.read(ARGV[0]), options: {
     render: { 
         github_pre_lang: true,
         unsafe: true 
-    }
+    },
+    extension: { footnotes: true }
 }, plugins: { 
     syntax_highlighter: nil 
 })

--- a/website/index.html
+++ b/website/index.html
@@ -8,7 +8,7 @@
                 <h2 class="title" style="margin-top: 2rem; font-size: 1.5rem; font-weight: 500;">Latest additions</h2>
             </div>
         </div>
-        <div class="columns" style="margin-top:-2rem">
+        <div class="columns" style="margin-top:0.5rem">
             <div class="column is-8-tablet is-offset-2-tablet is-10-mobile is-offset-1-mobile">
                 <!-- <p class="subtitle has-text-black">Latest packages</p> -->
                 <|| loop entries [entryLeft, entryRight][||>

--- a/website/style.scss
+++ b/website/style.scss
@@ -81,7 +81,9 @@ a.version-link {
 }
 
 .package-box {
-    margin-top: 2rem;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+
     padding: 0 !important;
 
     & > * {

--- a/website/style.scss
+++ b/website/style.scss
@@ -260,6 +260,11 @@ a.version-link {
                     code {
                         color: inherit !important;
                     }
+
+                    .footnotes {
+                        border-top: 1px solid #d0d7de;
+                        font-size: small;
+                    }
                 }
             }
         }

--- a/website/style.scss
+++ b/website/style.scss
@@ -261,6 +261,11 @@ a.version-link {
                         color: inherit !important;
                     }
 
+                    a {
+                        color: #485fc7 !important;
+                        text-decoration: underline !important;
+                    }
+
                     .footnote-ref {
                         a {
                             &::before {

--- a/website/style.scss
+++ b/website/style.scss
@@ -261,6 +261,17 @@ a.version-link {
                         color: inherit !important;
                     }
 
+                    .footnote-ref {
+                        a {
+                            &::before {
+                                content: '[';
+                            }
+                            &::after {
+                                content: ']';
+                            }
+                        }
+                    }
+
                     .footnotes {
                         border-top: 1px solid #d0d7de;
                         font-size: small;


### PR DESCRIPTION
# 📖 Description

This PR attempts to fix a couple of issues:

- [x] don't show repo name in the title of package pages; show the *package* name instead
- [x] filter tags that make sense on GitHub, but don't in pkgr.art (for example: a tag like `arturo-language` makes sense to exist here, so that a project can be found, but on pkgr.art not really... since... all of the package will be about Arturo 😉 )
- [x] replace dashes (`-`) in tags with spaces - this definitely looks better (we don't have to follow GitHub's own tag system, unless it makes total sense to do otherwise - in some cases(?))
- [x] fix look'n'feel (basically, the margins) in the initial "Latest additions" package list
- [x] properly parse footnotes within README markdown + style it accordingly
- [x] properly style links within README markdown (right now, they are there but you basically cannot... see them)
- [x] mark all *external* README links as `nofollow` and make them open in a different tab/window (`target="_blank"`)
- [x] arrange "Latest additions" so that the packages with the more-recently package versions appear first