### PR TITLE
Add `unidecode` package

### DIFF
--- a/packages/list.art
+++ b/packages/list.art
@@ -1,3 +1,4 @@
 dummy: "arturo-lang/dummy-package"
 states: "RickBarretto/states.art"
+unidecode: "drkameleon/unidecode.art"
 unitt: "RickBarretto/unitt"


### PR DESCRIPTION
# 📖 Description

👉  **Unicode -> Ascii converter**

The package is meant to replace our - currently part of the standard library - support for unicode-to-ascii conversion capabilities.

**See also:** https://github.com/arturo-lang/arturo/issues/1178

## 📦 New package

- [x] I have updated the [packages/list.art](https://github.com/arturo-lang/pkgr.art/blob/main/packages/list.art):
    * All you have to do is add an entry like:
       ```red
       packageName: "owner/repo"
       ```
- [x] The repo in question is formatted as a valid Arturo package:
    * either have a `main.art` file and/or an `info.art` file specifying the entry point, `depends` and `requires`
- [x] There is at least one published release:
    * Arturo's package manager versioning uses the published releases' tags which have to conform to SemVer
