### PR TITLE
Add `mimetypes` package

### DIFF
--- a/packages/list.art
+++ b/packages/list.art
@@ -1,6 +1,7 @@
 dummy: "arturo-lang/dummy-package"
 grafito: "arturo-lang/grafito"
 html: "arturo-lang/art-html-module"
+mimetypes: "drkameleon/mimetypes.art"
 states: "RickBarretto/states.art"
 unidecode: "drkameleon/unidecode.art"
 unitt: "RickBarretto/unitt"


### PR DESCRIPTION
# 📖 Description

MIME content type registry & recognition package for Arturo
https://github.com/drkameleon/mimetypes.art

## 📦 New package

- [x] I have updated the [packages/list.art](https://github.com/arturo-lang/pkgr.art/blob/main/packages/list.art):
    * All you have to do is add an entry like:
       ```red
       packageName: "owner/repo"
       ```
- [x] The repo in question is formatted as a valid Arturo package:
    * either have a `main.art` file and/or an `info.art` file specifying the entry point, `depends` and `requires`
- [x] There is at least one published release:
    * Arturo's package manager versioning uses the published releases' tags which have to conform to SemVer
