### PR TITLE
Add `grace` package

### DIFF
--- a/packages/list.art
+++ b/packages/list.art
@@ -1,6 +1,7 @@
 artsembly:      gh "arturo-lang/artsembly"
 claude:         gh "drkameleon/claude.ai.art"
 dummy:          gh "arturo-lang/dummy-package"
+grace:          gh "drkameleon/grace.art"
 grafito:        gh "arturo-lang/grafito"
 html:           gh "arturo-lang/art-html-module"
 mathjax:        cb "Eloitor/mathjax.art"


### PR DESCRIPTION
# 📖 Description

See: https://github.com/drkameleon/grace.art

## 📦 New package

- [x] I have updated the [packages/list.art](https://github.com/arturo-lang/pkgr.art/blob/main/packages/list.art):
    * All you have to do is add an entry like:
       ```red
       packageName: "owner/repo"
       ```
- [x] The repo in question is formatted as a valid Arturo package:
    * either have a `main.art` file and/or an `info.art` file specifying the entry point, `depends` and `requires`
- [x] There is at least one published release:
    * Arturo's package manager versioning uses the published releases' tags which have to conform to SemVer
