### PR TITLE
Fix obsolete `as` references

### DIFF
--- a/tools/deploy.art
+++ b/tools/deploy.art
@@ -35,10 +35,10 @@ do ::
         targetFolder: "packages"
 
         infoD: getRepoInfo pkg
-        write as.unwrapped.pretty.code infoD ~"|targetFolder|/info/|targetName|" 
+        write express.unwrapped.pretty infoD ~"|targetFolder|/info/|targetName|" 
 
         versionD: getVersions pkg
-        write as.pretty.code versionD ~"|targetFolder|/version/|targetName|" 
+        write express.pretty versionD ~"|targetFolder|/version/|targetName|" 
 
         print color #green "[ ✅  OK   ]"  
 
@@ -50,7 +50,7 @@ do ::
         cnt: cnt + 1
     ]
 
-    write as.unwrapped.pretty.code listWithDescriptions ~"public/list.art" 
+    write express.unwrapped.pretty listWithDescriptions ~"public/list.art" 
 
     print separator
     print ""

--- a/tools/generateweb.art
+++ b/tools/generateweb.art
@@ -156,7 +156,7 @@ createSpecFile: function [package, versionToProcess, targetFolder][
         requires: versionToProcess\info\requires
     ]
 
-    write replace strip as.pretty.unwrapped.code ret {/\[\n\n\s+\]/} "[]" ~"|targetFolder|/spec" 
+    write replace strip express.pretty.unwrapped ret {/\[\n\n\s+\]/} "[]" ~"|targetFolder|/spec" 
 ]
 
 searchable: new []


### PR DESCRIPTION
# 📖 Description

Let's make [the action run without issues](https://github.com/arturo-lang/pkgr.art/actions/runs/16519304455) and fix some older references to `as` (which doesn't exist anymore)
