### PR TITLE
Add {Art}cism

### DIFF
--- a/packages/list.art
+++ b/packages/list.art
@@ -1,3 +1,4 @@
+artcism:        gh "RickBarretto/Artcism"
 artsembly:      gh "arturo-lang/artsembly"
 claude:         gh "drkameleon/claude.ai.art"
 dummy:          gh "arturo-lang/dummy-package"


### PR DESCRIPTION
An Exercism Runner for Arturo Programming Language.

# 📖 Description

An Exercism Runner for Arturo Programming Language. 
This package uses `unitt` behind the scenes keeping the same base syntax.

## 📦 New package

- [x] I have updated the [packages/list.art](https://github.com/arturo-lang/pkgr.art/blob/main/packages/list.art):
    * All you have to do is add an entry like:
       ```red
       packageName: "owner/repo"
       ```
- [x] The repo in question is formatted as a valid Arturo package:
    * either have a `main.art` file and/or an `info.art` file specifying the entry point, `depends` and `requires`
- [x] There is at least one published release:
    * Arturo's package manager versioning uses the published releases' tags which have to conform to SemVer
